### PR TITLE
Update code to handle multi line arguments

### DIFF
--- a/src/discussiontree.py
+++ b/src/discussiontree.py
@@ -14,10 +14,6 @@ class DiscussionTree():
         last_index = re.search(r"^(\d+.)+", title_claim).group()
         stance = None
         content = re.match(r"^(\d+.)+ *(.*)", title_claim).group(2)
-        if filename.endswith('2629.txt'):
-            debug = True
-        else:
-            debug = False
         for claim in self.claims:
             if re.search(r"^(\d+.)+", claim) is None:
                 continue

--- a/src/discussiontree.py
+++ b/src/discussiontree.py
@@ -1,33 +1,43 @@
 import re
+from packaging import version
+
 
 class DiscussionTree():
     def __init__(self, filename=None):
         with open(filename, "r") as file:
-            lines = file.read().splitlines() 
+            lines = file.read().splitlines()
 
         self.title = lines[0].split(":", 1)[1][1:]
-        self.claims = lines[2:]    
-        
+        self.claims = lines[3:]
         self.tree = {}
-        
+        title_claim = lines[2]
+        last_index = re.search(r"^(\d+.)+", title_claim).group()
+        stance = None
+        content = re.match(r"^(\d+.)+ *(.*)", title_claim).group(2)
+        if filename.endswith('2629.txt'):
+            debug = True
+        else:
+            debug = False
         for claim in self.claims:
-            if re.search(r"^(\d{1,}.)+", claim) is None:
-                # print(f"WARNING: No index detected in {filename} for claim {claim}")
+            if re.search(r"^(\d+.)+", claim) is None:
                 continue
-            index =  re.search(r"^(\d{1,}.)+", claim).group()
-            if re.search(r"(Con|Pro)(?::)|None", claim) is not None:
-                stance = re.search(r"(Con|Pro)(?::)|None", claim).group(1)
-                content = re.search(r"((Con|Pro)(?::\s))(.*)", claim).group(3)
-            else: 
-                stance = None
-                content = re.match(r"^(\d{1,}.)+ *(.*)", claim).group(2)
-            try:
-                self.set_entry(index, {"index":index, "stance":stance, "content":content})
-            except IndexError:
-                # print(f"WARNING: KeyError while saving entry in {filename} for index {index}")
-                continue
-    
-    def find(self, search_string:str):
+            index = re.search(r"^(\d+.)+", claim).group()
+            # if debug:
+            #     print(index, last_index)
+            if index.startswith('1.') and version.parse(index) > version.parse(last_index):
+                self.set_entry(last_index, {"index": last_index, "stance": stance, "content": content})
+                last_index = index
+                if re.search(r"(Con|Pro)(?::)|None", claim) is not None:
+                    stance = re.search(r"(Con|Pro)(?::)|None", claim).group(1)
+                    content = re.search(r"((Con|Pro)(?::\s))(.*)", claim).group(3)
+                else:
+                    stance = None
+                    content = re.match(r"^(\d+.)+ *(.*)", claim).group(2)
+            else:
+                content += re.match(r"^(\d+.)+ *(.*)", claim).group(2)
+        self.set_entry(index, {"index": index, "stance": stance, "content": content})
+
+    def find(self, search_string: str):
         """ Finds claims that contain a certain string.
         
             params:
@@ -39,13 +49,13 @@ class DiscussionTree():
         indices = []
         for claim in self.claims:
             if re.search(search_string, claim, re.IGNORECASE) is not None:
-                index_re =  re.search(r"^(\d{1,}.)+", claim)
+                index_re = re.search(r"^(\d+.)+", claim)
                 if index_re is not None:
                     indices.append(index_re.group())
-        
+
         return indices
 
-    def find_list(self, search_string_list:list):
+    def find_list(self, search_string_list: list):
         """ Finds claims that contain one of a list of string.
         
             params:
@@ -57,18 +67,18 @@ class DiscussionTree():
         indices = []
         for claim in self.claims:
             for search_string in search_string_list:
-                index_re =  re.search(r"^(\d{1,}.)+", claim)
+                index_re = re.search(r"^(\d+.)+", claim)
                 if index_re is not None:
                     indices.append(index_re.group())
-        
+
         return indices
 
     def get_title(self):
         return self.title
-    
+
     def get_claims(self):
         return self.claims
-        
+
     def get_entry(self, index):
         """ params:
                 index: keyspec of the form "(d\.)+"
@@ -77,10 +87,11 @@ class DiscussionTree():
                 node at given index
         """
         return self._get_node(self._get_entry(index))
-    
+
     def _get_node(self, subtree):
-        return {"index":subtree["index"], "content":subtree["content"], "stance":subtree["stance"]} if "index" in subtree.keys() else {}
-    
+        return {"index": subtree["index"], "content": subtree["content"],
+                "stance": subtree["stance"]} if "index" in subtree.keys() else {}
+
     def _get_entry(self, index):
         """ params:
                 index: keyspec of the form "(d\.)+"
@@ -90,12 +101,12 @@ class DiscussionTree():
         """
         if index == '.':
             return self.tree
-        
+
         keys = self._index_to_keys(index)
 
         result = self.tree[keys[0]]
         for key in keys[1:]:
-           result = result[key]
+            result = result[key]
 
         return result
 
@@ -105,7 +116,6 @@ class DiscussionTree():
                 entry: dict at given index
         """
         keys = self._index_to_keys(index)
-
         level = self.tree
         for key in keys[:-1]:
             if key in level:
@@ -114,7 +124,7 @@ class DiscussionTree():
                 level[key] = {}
                 level = level[key]
         level[keys[-1]] = entry
-    
+
     def get_parent(self, index):
         """ params:
                 index: keyspec of the form "(d\.)+"
@@ -123,8 +133,10 @@ class DiscussionTree():
                 dict at parent of given index, or empty dict if index is root
         """
         parent_index = self._get_parent_index(index)
+        if parent_index=='.':
+            return None
         return self.get_entry(parent_index)
-    
+
     def get_children(self, index):
         """ params:
                 index: keyspec of the form "(d\.)+"
@@ -153,10 +165,9 @@ class DiscussionTree():
             if key not in ["index", "content", "stance"] and subtree[key]["index"] != index:
                 result.append(self._get_node(subtree[key]))
         return result
-    
+
     def _index_to_keys(self, index):
         return index.split('.')[:-1]
-    
+
     def _get_parent_index(self, index):
         return '.'.join(self._index_to_keys(index)[:-1]) + '.'
-    


### PR DESCRIPTION
Previous code was treating claims as single liners, which caused errors for arguments like this:

1.4.3 Pro: XYZ is true for the following reasons
1. ABC
2. DEF
1.4.4

Change get_parent_node to return None if a parent does not exist